### PR TITLE
Problem: query decimals get reverted when Display doesn't match with DenomUnit for ibc token

### DIFF
--- a/precompiles/erc20/query.go
+++ b/precompiles/erc20/query.go
@@ -113,7 +113,14 @@ func (p Precompile) Decimals(
 		displayFound bool
 	)
 	for i := len(metadata.DenomUnits) - 1; i >= 0; i-- {
-		if metadata.DenomUnits[i].Denom == metadata.Display {
+		var match bool
+		if strings.HasPrefix(metadata.Base, "ibc/") {
+			displays := strings.Split(metadata.Display, "/")
+			match = metadata.DenomUnits[i].Denom == displays[len(displays)-1]
+		} else {
+			match = metadata.DenomUnits[i].Denom == metadata.Display
+		}
+		if match {
 			decimals = metadata.DenomUnits[i].Exponent
 			displayFound = true
 			break

--- a/tests/integration/precompiles/erc20/test_query.go
+++ b/tests/integration/precompiles/erc20/test_query.go
@@ -319,6 +319,54 @@ func (s *PrecompileTestSuite) TestDecimals() {
 			},
 			errContains: vm.ErrExecutionReverted.Error(),
 		},
+		{
+			name:  "pass - valid IBC denom with metadata using display path",
+			denom: "ibc/B89BE1E96B3DBC0ABB05F858F08561BA12B9C5E420CA2F5E83C475CCB47A834E",
+			malleate: func(ctx sdk.Context, keeper bankkeeper.Keeper, _ transferkeeper.Keeper) {
+				keeper.SetDenomMetaData(ctx, banktypes.Metadata{
+					Base: "ibc/B89BE1E96B3DBC0ABB05F858F08561BA12B9C5E420CA2F5E83C475CCB47A834E",
+					DenomUnits: []*banktypes.DenomUnit{
+						{
+							Denom:    "ibc/B89BE1E96B3DBC0ABB05F858F08561BA12B9C5E420CA2F5E83C475CCB47A834E",
+							Exponent: 0,
+						},
+						{
+							Denom:    "uom",
+							Exponent: 6,
+						},
+					},
+					Display: "transfer/channel-0/uom",
+					Name:    "transfer/channel-0/uom IBC token",
+					Symbol:  "UOM",
+				})
+			},
+			expPass:     true,
+			expDecimals: 6,
+		},
+		{
+			name:  "fail - IBC denom with metadata but no matching display unit",
+			denom: "ibc/C1D2E3F4567890123456789012345678901234567890123456789012345678901234",
+			malleate: func(ctx sdk.Context, keeper bankkeeper.Keeper, _ transferkeeper.Keeper) {
+				keeper.SetDenomMetaData(ctx, banktypes.Metadata{
+					Base: "ibc/C1D2E3F4567890123456789012345678901234567890123456789012345678901234",
+					DenomUnits: []*banktypes.DenomUnit{
+						{
+							Denom:    "ibc/C1D2E3F4567890123456789012345678901234567890123456789012345678901234",
+							Exponent: 0,
+						},
+						{
+							Denom:    "nomatch",
+							Exponent: 6,
+						},
+					},
+					Display: "transfer/channel-0/lastpart",
+					Name:    "Mismatched Token",
+					Symbol:  "MISMATCH",
+				})
+			},
+			expPass:     false,
+			errContains: "execution reverted",
+		},
 	}
 
 	for _, tc := range testcases {


### PR DESCRIPTION
# Description

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review. -->

<!-- Please keep your PR as draft until it's ready for review -->

<!-- Pull requests that sit inactive for longer than 30 days will be closed.  -->

Closes: #XXXX

---

## Author Checklist

**All** items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.

I have...

- [ ] tackled an existing issue or discussed with a team member
- [ ] left instructions on how to review the changes
- [ ] targeted the `main` branch
