### PR TITLE
fix: cleanup unused cancel function in filter

### DIFF
--- a/rpc/namespaces/ethereum/eth/filters/api.go
+++ b/rpc/namespaces/ethereum/eth/filters/api.go
@@ -65,7 +65,6 @@ type filter struct {
 	typ      filters.Type
 	deadline *time.Timer // filter is inactive when deadline triggers
 	crit     filters.FilterCriteria
-	cancel   context.CancelFunc
 	offset   int // offset for stream subscription
 }
 
@@ -128,7 +127,6 @@ func (api *PublicFilterAPI) timeoutLoop() {
 		for id, f := range api.filters {
 			select {
 			case <-f.deadline.C:
-				f.cancel()
 				delete(api.filters, id)
 			default:
 				continue


### PR DESCRIPTION
# Description

missing [change](https://github.com/crypto-org-chain/ethermint/pull/387) when upstream, which takes [5mins](https://github.com/MANTRA-Chain/evm/blob/951b264442f6ace079a0583c8cd6da49630848e0/rpc/namespaces/ethereum/eth/filters/api.go#L60) to trigger the panic.

Closes: #XXXX

---

## Author Checklist

**All** items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.

I have...

- [ ] tackled an existing issue or discussed with a team member
- [ ] left instructions on how to review the changes
- [ ] targeted the `main` branch
