### PR TITLE
fix: apply multi decode functions instead of string contains check in HexAddressFromBech32String

### DIFF
--- a/utils/utils_test.go
+++ b/utils/utils_test.go
@@ -742,3 +742,35 @@ func TestCalcBaseFee(t *testing.T) {
 		})
 	}
 }
+
+func TestHexAddressFromBech32String(t *testing.T) {
+	accAddr := "cosmos16val7w9lc7wltqvpt0kscaul4xd6l2l43nhcq4"
+	valAddr := "cosmosvaloper16val7w9lc7wltqvpt0kscaul4xd6l2l458rdvx"
+	consAddr := "cosmosvalcons16val7w9lc7wltqvpt0kscaul4xd6l2l4q5s3q8"
+	invalidAddr := "invalid1address"
+	expectedHex := "0xd33bFF38Bfc79df581815BED0c779FA99BaFAbf5"
+
+	testCases := []struct {
+		name      string
+		input     string
+		wantHex   string
+		wantError bool
+	}{
+		{"account address", accAddr, expectedHex, false},
+		{"validator address", valAddr, expectedHex, false},
+		{"consensus address", consAddr, expectedHex, false},
+		{"invalid address", invalidAddr, "", true},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			addr, err := utils.HexAddressFromBech32String(tc.input)
+			if tc.wantError {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+				require.Equal(t, tc.wantHex, addr.Hex())
+			}
+		})
+	}
+}

--- a/x/erc20/client/cli/query.go
+++ b/x/erc20/client/cli/query.go
@@ -63,6 +63,7 @@ func GetTokenPairsCmd() *cobra.Command {
 	}
 
 	flags.AddQueryFlagsToCmd(cmd)
+	flags.AddPaginationFlagsToCmd(cmd, "token-pairs")
 	return cmd
 }
 


### PR DESCRIPTION
* fix: apply multi decode functions instead of string contains check in HexAddressFromBech32String

* align for account, validator, and consensus addresses like sdk
* https://github.com/cosmos/cosmos-sdk/blob/release/v0.53.x/client/debug/main.go#L262

* test

# Description

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review. -->

<!-- Please keep your PR as draft until it's ready for review -->

<!-- Pull requests that sit inactive for longer than 30 days will be closed.  -->

Closes: #XXXX

---

## Author Checklist

**All** items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.

I have...

- [ ] tackled an existing issue or discussed with a team member
- [ ] left instructions on how to review the changes
- [ ] targeted the `main` branch
