### PR TITLE
feat: allow IBC fee denoms

### DIFF
--- a/ante/evm/fee_checker.go
+++ b/ante/evm/fee_checker.go
@@ -38,6 +38,13 @@ func NewDynamicFeeChecker(feemarketParams *feemarkettypes.Params) authante.TxFee
 			return checkTxFeeWithValidatorMinGasPrices(ctx, feeTx)
 		}
 		denom := evmtypes.GetEVMCoinDenom()
+		feeCoins := feeTx.GetFee()
+
+		// If the tx fee is not paid in the EVM denom (e.g. `ibc/<hash>`), skip EIP-1559
+		// checks and fall back to validator min-gas-prices.
+		if len(feeCoins) == 1 && feeCoins.GetDenomByIndex(0) != denom {
+			return checkTxFeeWithValidatorMinGasPrices(ctx, feeTx)
+		}
 		ethCfg := evmtypes.GetEthChainConfig()
 
 		return FeeChecker(ctx, feemarketParams, denom, ethCfg, feeTx)

--- a/tests/integration/ante/test_min_gas_price.go
+++ b/tests/integration/ante/test_min_gas_price.go
@@ -65,6 +65,22 @@ func (s *AnteTestSuite) TestMinGasPriceDecorator() {
 			true,
 		},
 		{
+			"valid cosmos tx with ibc denom fee",
+			func() sdk.Tx {
+				params := nw.App.GetFeeMarketKeeper().GetParams(ctx)
+				params.MinGasPrice = math.LegacyZeroDec()
+				err := nw.App.GetFeeMarketKeeper().SetParams(ctx, params)
+				s.Require().NoError(err)
+
+				ibcDenom := "ibc/DEADBEEF"
+				txBuilder := s.CreateTestCosmosTxBuilder(math.NewInt(0), ibcDenom, &testMsg)
+				return txBuilder.GetTx()
+			},
+			true,
+			"",
+			true,
+		},
+		{
 			"valid cosmos tx with MinGasPrices = 0, gasPrice > 0",
 			func() sdk.Tx {
 				params := nw.App.GetFeeMarketKeeper().GetParams(ctx)


### PR DESCRIPTION
# Description

* allow ibc/<hash> vouchers as fee denoms in MinGasPriceDecorator
* fall back to validator min-gas-prices when fees aren't paid in the EVM denom

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review. -->

<!-- Please keep your PR as draft until it's ready for review -->

<!-- Pull requests that sit inactive for longer than 30 days will be closed.  -->

Closes: #XXXX

---

## Author Checklist

**All** items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.

I have...

- [ ] tackled an existing issue or discussed with a team member
- [ ] left instructions on how to review the changes
- [ ] targeted the `main` branch
