### PR TITLE
fix(ibc): block nested ICS20 forwarding in src callbacks (#1061)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ Follow the [migration document](docs/migrations/v0.5.x_to_v0.6.0.md) for upgrade
 
 ### BUG FIXES
 
+- [\#1061](https://github.com/cosmos/evm/pull/1061) Block nested ICS20 forwarding in source callbacks.
+
 ## v0.5.1
 
 ### DEPENDENCIES

--- a/go.sum
+++ b/go.sum
@@ -761,12 +761,8 @@ github.com/bytedance/gopkg v0.1.3 h1:TPBSwH8RsouGCBcMBktLt1AymVo2TVsBVCY4b6TnZ/M
 github.com/bytedance/gopkg v0.1.3/go.mod h1:576VvJ+eJgyCzdjS+c4+77QF3p7ubbtiKARP3TxducM=
 github.com/bytedance/sonic v1.5.0/go.mod h1:ED5hyg4y6t3/9Ku1R6dU/4KyJ48DZ4jPhfY1O2AihPM=
 github.com/bytedance/sonic v1.9.1/go.mod h1:i736AoUSYt75HyZLoJW9ERYxcy6eaN6h4BZXU064P/U=
-github.com/bytedance/sonic v1.14.2 h1:k1twIoe97C1DtYUo+fZQy865IuHia4PR5RPiuGPPIIE=
-github.com/bytedance/sonic v1.14.2/go.mod h1:T80iDELeHiHKSc0C9tubFygiuXoGzrkjKzX2quAx980=
 github.com/bytedance/sonic v1.15.0 h1:/PXeWFaR5ElNcVE84U0dOHjiMHQOwNIx3K4ymzh/uSE=
 github.com/bytedance/sonic v1.15.0/go.mod h1:tFkWrPz0/CUCLEF4ri4UkHekCIcdnkqXw9VduqpJh0k=
-github.com/bytedance/sonic/loader v0.4.0 h1:olZ7lEqcxtZygCK9EKYKADnpQoYkRQxaeY2NYzevs+o=
-github.com/bytedance/sonic/loader v0.4.0/go.mod h1:AR4NYCk5DdzZizZ5djGqQ92eEhCCcdf5x77udYiSJRo=
 github.com/bytedance/sonic/loader v0.5.0 h1:gXH3KVnatgY7loH5/TkeVyXPfESoqSBSBEiDd5VjlgE=
 github.com/bytedance/sonic/loader v0.5.0/go.mod h1:AR4NYCk5DdzZizZ5djGqQ92eEhCCcdf5x77udYiSJRo=
 github.com/casbin/casbin/v2 v2.1.2/go.mod h1:YcPU1XXisHhLzuxH9coDNf2FbKpjGlbCg3n9yuLkIJQ=

--- a/precompiles/ics20/tx.go
+++ b/precompiles/ics20/tx.go
@@ -11,6 +11,7 @@ import (
 
 	cmn "github.com/cosmos/evm/precompiles/common"
 	erc20types "github.com/cosmos/evm/x/erc20/types"
+	callbackstypes "github.com/cosmos/evm/x/ibc/callbacks/types"
 	"github.com/cosmos/evm/x/vm/statedb"
 	transfertypes "github.com/cosmos/ibc-go/v10/modules/apps/transfer/types"
 	connectiontypes "github.com/cosmos/ibc-go/v10/modules/core/03-connection/types"
@@ -189,6 +190,11 @@ func (p *Precompile) Transfer(
 	method *abi.Method,
 	args []interface{},
 ) ([]byte, error) {
+	// Marker is set in the callbacks keeper and propagates here via cacheCtx.
+	if callbackstypes.IsSourceCallbackExecution(ctx) {
+		return nil, callbackstypes.ErrNestedSourceCallbackTransfer
+	}
+
 	msg, sender, err := NewMsgTransfer(method, args)
 	if err != nil {
 		return nil, err

--- a/precompiles/ics20/tx_callback_guard_test.go
+++ b/precompiles/ics20/tx_callback_guard_test.go
@@ -1,0 +1,24 @@
+package ics20
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	callbackstypes "github.com/cosmos/evm/x/ibc/callbacks/types"
+
+	storetypes "github.com/cosmos/cosmos-sdk/store/v2/types"
+	sdktestutil "github.com/cosmos/cosmos-sdk/testutil"
+)
+
+func TestTransfer_BlockedDuringSourceCallbackExecution(t *testing.T) {
+	storeKey := storetypes.NewKVStoreKey("test")
+	tKey := storetypes.NewTransientStoreKey("test_t")
+	ctx := sdktestutil.DefaultContext(storeKey, tKey)
+	ctx = callbackstypes.WithSourceCallbackExecution(ctx)
+	p := &Precompile{}
+	_, err := p.Transfer(ctx, nil, nil, nil, nil)
+	require.Error(t, err)
+	require.True(t, errors.Is(err, callbackstypes.ErrNestedSourceCallbackTransfer))
+}

--- a/precompiles/ics20/tx_callback_guard_test.go
+++ b/precompiles/ics20/tx_callback_guard_test.go
@@ -8,7 +8,8 @@ import (
 
 	callbackstypes "github.com/cosmos/evm/x/ibc/callbacks/types"
 
-	storetypes "github.com/cosmos/cosmos-sdk/store/v2/types"
+	storetypes "cosmossdk.io/store/types"
+
 	sdktestutil "github.com/cosmos/cosmos-sdk/testutil"
 )
 

--- a/x/ibc/callbacks/keeper/keeper.go
+++ b/x/ibc/callbacks/keeper/keeper.go
@@ -299,6 +299,7 @@ func (k ContractKeeper) IBCOnAcknowledgementPacketCallback(
 	cachedCtx, writeFn := ctx.CacheContext()
 	cachedCtx = evmante.BuildEvmExecutionCtx(cachedCtx).
 		WithGasMeter(evmtypes.NewInfiniteGasMeterWithLimit(cbData.CommitGasLimit))
+	cachedCtx = types.WithSourceCallbackExecution(cachedCtx)
 	stateDB := statedb.New(cachedCtx, k.evmKeeper, statedb.NewEmptyTxConfig())
 
 	if len(cbData.Calldata) != 0 {
@@ -400,6 +401,7 @@ func (k ContractKeeper) IBCOnTimeoutPacketCallback(
 	cachedCtx, writeFn := ctx.CacheContext()
 	cachedCtx = evmante.BuildEvmExecutionCtx(cachedCtx).
 		WithGasMeter(evmtypes.NewInfiniteGasMeterWithLimit(cbData.CommitGasLimit))
+	cachedCtx = types.WithSourceCallbackExecution(cachedCtx)
 	stateDB := statedb.New(cachedCtx, k.evmKeeper, statedb.NewEmptyTxConfig())
 
 	if len(cbData.Calldata) != 0 {

--- a/x/ibc/callbacks/types/context.go
+++ b/x/ibc/callbacks/types/context.go
@@ -1,0 +1,19 @@
+package types
+
+import (
+	sdk "github.com/cosmos/cosmos-sdk/types"
+)
+
+type sourceCallbackCtxKey struct{}
+
+// WithSourceCallbackExecution marks a context as executing a source callback.
+func WithSourceCallbackExecution(ctx sdk.Context) sdk.Context {
+	return ctx.WithValue(sourceCallbackCtxKey{}, true)
+}
+
+// IsSourceCallbackExecution returns true when executing inside a source callback.
+func IsSourceCallbackExecution(ctx sdk.Context) bool {
+	v := ctx.Value(sourceCallbackCtxKey{})
+	b, ok := v.(bool)
+	return ok && b
+}

--- a/x/ibc/callbacks/types/context_test.go
+++ b/x/ibc/callbacks/types/context_test.go
@@ -1,0 +1,20 @@
+package types
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	storetypes "github.com/cosmos/cosmos-sdk/store/v2/types"
+	sdktestutil "github.com/cosmos/cosmos-sdk/testutil"
+)
+
+func TestSourceCallbackExecutionContextMarker(t *testing.T) {
+	storeKey := storetypes.NewKVStoreKey("test")
+	tKey := storetypes.NewTransientStoreKey("test_t")
+	ctx := sdktestutil.DefaultContext(storeKey, tKey)
+	require.False(t, IsSourceCallbackExecution(ctx))
+	callbackCtx := WithSourceCallbackExecution(ctx)
+	require.True(t, IsSourceCallbackExecution(callbackCtx))
+	require.False(t, IsSourceCallbackExecution(ctx))
+}

--- a/x/ibc/callbacks/types/context_test.go
+++ b/x/ibc/callbacks/types/context_test.go
@@ -5,7 +5,8 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	storetypes "github.com/cosmos/cosmos-sdk/store/v2/types"
+	storetypes "cosmossdk.io/store/types"
+
 	sdktestutil "github.com/cosmos/cosmos-sdk/testutil"
 )
 

--- a/x/ibc/callbacks/types/errors.go
+++ b/x/ibc/callbacks/types/errors.go
@@ -6,13 +6,14 @@ import (
 
 // EVM sentinel callback errors
 var (
-	ErrInvalidReceiverAddress = errorsmod.Register(ModuleName, 1, "invalid receiver address")
-	ErrCallbackFailed         = errorsmod.Register(ModuleName, 2, "callback failed")
-	ErrInvalidCalldata        = errorsmod.Register(ModuleName, 3, "invalid calldata in callback data")
-	ErrContractHasNoCode      = errorsmod.Register(ModuleName, 4, "contract has no code")
-	ErrTokenPairNotFound      = errorsmod.Register(ModuleName, 5, "token not registered")
-	ErrNumberOverflow         = errorsmod.Register(ModuleName, 6, "number overflow")
-	ErrAllowanceFailed        = errorsmod.Register(ModuleName, 7, "allowance failed")
-	ErrEVMCallFailed          = errorsmod.Register(ModuleName, 8, "evm call failed")
-	ErrOutOfGas               = errorsmod.Register(ModuleName, 9, "out of gas")
+	ErrInvalidReceiverAddress       = errorsmod.Register(ModuleName, 1, "invalid receiver address")
+	ErrCallbackFailed               = errorsmod.Register(ModuleName, 2, "callback failed")
+	ErrInvalidCalldata              = errorsmod.Register(ModuleName, 3, "invalid calldata in callback data")
+	ErrContractHasNoCode            = errorsmod.Register(ModuleName, 4, "contract has no code")
+	ErrTokenPairNotFound            = errorsmod.Register(ModuleName, 5, "token not registered")
+	ErrNumberOverflow               = errorsmod.Register(ModuleName, 6, "number overflow")
+	ErrAllowanceFailed              = errorsmod.Register(ModuleName, 7, "allowance failed")
+	ErrEVMCallFailed                = errorsmod.Register(ModuleName, 8, "evm call failed")
+	ErrOutOfGas                     = errorsmod.Register(ModuleName, 9, "out of gas")
+	ErrNestedSourceCallbackTransfer = errorsmod.Register(ModuleName, 10, "ics20 transfer is not allowed during source callback execution")
 )


### PR DESCRIPTION
* fix(ibc): block nested ICS20 forwarding in src callbacks

* mark source callback evm execution in context
* reject precompile transfer call during source callbacks to avoid nested forwarding

* fix ctx

* test

* fix lints

* Update CHANGELOG.md



* cleanup

---------

# Description

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review. -->

<!-- Please keep your PR as draft until it's ready for review -->

<!-- Pull requests that sit inactive for longer than 30 days will be closed.  -->

Closes: #XXXX

---

## Author Checklist

**All** items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.

I have...

- [ ] tackled an existing issue or discussed with a team member
- [ ] left instructions on how to review the changes
- [ ] targeted the `main` branch
