### PR TITLE
Problem: eth_call over-reports gas for native precompiles

### DIFF
--- a/encoding/address/address_codec_test.go
+++ b/encoding/address/address_codec_test.go
@@ -153,7 +153,8 @@ func TestBytesToString(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			got, err := cdc.BytesToString(tc.input())
+			in := tc.input()
+			got, err := cdc.BytesToString(in)
 			if tc.expErr == nil {
 				require.NoError(t, err)
 				require.Equal(t, tc.expRes, got)

--- a/tests/integration/precompiles/erc20/test_integration.go
+++ b/tests/integration/precompiles/erc20/test_integration.go
@@ -327,10 +327,8 @@ func TestIntegrationTestSuite(t *testing.T, create network.CreateEvmApp, options
 					Expect(res.GasUsed).To(BeNumerically(">", expGasUsedLowerBound), "expected more gas used")
 					Expect(res.GasUsed).To(BeNumerically("<", expGasUsedUpperBound), "expected less gas used")
 				},
-					// Direct precompile calls correctly include cosmos-sdk KV gas
-					// (account loads, balance reads, etc.) since `buildTraceCtx`
-					// preserves KvGasConfig for native precompile recipients.
-					Entry(" - direct call", directCall, int64(44_000), int64(46_000)),
+					// FIXME: The gas used on the precompile is much higher than on the EVM
+					Entry(" - direct call", directCall, int64(30_000), int64(31_000)),
 					Entry(" - through erc20 contract", erc20Call, int64(53_000), int64(54_500)),
 					Entry(" - through erc20 v5 contract", erc20V5Call, int64(52_000), int64(52_200)),
 				)

--- a/tests/integration/precompiles/erc20/test_integration.go
+++ b/tests/integration/precompiles/erc20/test_integration.go
@@ -327,8 +327,10 @@ func TestIntegrationTestSuite(t *testing.T, create network.CreateEvmApp, options
 					Expect(res.GasUsed).To(BeNumerically(">", expGasUsedLowerBound), "expected more gas used")
 					Expect(res.GasUsed).To(BeNumerically("<", expGasUsedUpperBound), "expected less gas used")
 				},
-					// FIXME: The gas used on the precompile is much higher than on the EVM
-					Entry(" - direct call", directCall, int64(30_000), int64(31_000)),
+					// Direct precompile calls correctly include cosmos-sdk KV gas
+					// (account loads, balance reads, etc.) since `buildTraceCtx`
+					// preserves KvGasConfig for native precompile recipients.
+					Entry(" - direct call", directCall, int64(44_000), int64(46_000)),
 					Entry(" - through erc20 contract", erc20Call, int64(53_000), int64(54_500)),
 					Entry(" - through erc20 v5 contract", erc20V5Call, int64(52_000), int64(52_200)),
 				)

--- a/x/vm/keeper/grpc_query.go
+++ b/x/vm/keeper/grpc_query.go
@@ -379,17 +379,9 @@ func (k Keeper) EstimateGasInternal(c context.Context, req *types.EthCallRequest
 
 	// create a helper to check if a gas allowance results in an executable transaction
 	executable := func(gas uint64) (vmError bool, rsp *types.MsgEthereumTxResponse, err error) {
-		// Treat cosmos meter OOM panics (preserve-KvGasConfig mode) as a
-		// "raise gas" signal so the binary search continues.
-		defer func() {
-			if r := recover(); r != nil {
-				if _, ok := r.(storetypes.ErrorOutOfGas); ok {
-					vmError, rsp, err = true, nil, nil
-					return
-				}
-				panic(r)
-			}
-		}()
+		// Convert cosmos meter OOM (panic or return) into a "raise gas" signal.
+		defer rewriteOutOfGasAsRaiseGas(&vmError, &rsp, &err)
+		defer recoverMeterOOM(&err)
 
 		// update the message with the new gas value
 		msg.GasLimit = gas
@@ -419,7 +411,7 @@ func (k Keeper) EstimateGasInternal(c context.Context, req *types.EthCallRequest
 		stateDB := statedb.New(tmpCtx, &k, txConfig)
 		rsp, err = k.ApplyMessageWithConfig(tmpCtx, stateDB, *msg, nil, false, false, cfg, txConfig, false, nil)
 		if err != nil {
-			if errors.Is(err, core.ErrIntrinsicGas) || errors.Is(err, core.ErrFloorDataGas) {
+			if errors.Is(err, core.ErrIntrinsicGas) || errors.Is(err, core.ErrFloorDataGas) || errors.Is(err, vm.ErrOutOfGas) {
 				return true, nil, nil // Special case, raise gas limit
 			}
 			return true, nil, err // Bail out
@@ -570,11 +562,16 @@ func (k Keeper) TraceTx(c context.Context, req *types.QueryTraceTxRequest) (*typ
 		// we ignore the error here. this endpoint, ideally, is called internally from the ETH backend, which will call this query
 		// using all previous txs in the trace transaction's block. some of those _could_ be invalid transactions.
 		stateDB := statedb.New(ctx, &k, txConfig)
-		rsp, _ := k.ApplyMessageWithConfig(ctx, stateDB, *msg, nil, true, false, cfg, txConfig, false, nil)
-		if rsp != nil {
-			ctx.GasMeter().ConsumeGas(rsp.GasUsed, "evm predecessor tx")
-			txConfig.LogIndex += uint(len(rsp.Logs))
-		}
+		// Closure-scoped recover so one predecessor's OOM doesn't abort the trace.
+		func() {
+			var applyErr error
+			defer recoverMeterOOM(&applyErr)
+			rsp, _ := k.ApplyMessageWithConfig(ctx, stateDB, *msg, nil, true, false, cfg, txConfig, false, nil)
+			if applyErr == nil && rsp != nil {
+				ctx.GasMeter().ConsumeGas(rsp.GasUsed, "evm predecessor tx")
+				txConfig.LogIndex += uint(len(rsp.Logs))
+			}
+		}()
 	}
 
 	tx := req.Msg.AsTransaction()
@@ -772,13 +769,12 @@ func (k *Keeper) traceTxWithMsg(
 	msg *core.Message,
 	traceConfig *types.TraceConfig,
 	commitMessage bool,
-) (*interface{}, uint, error) {
+) (_ *interface{}, _ uint, err error) {
 	// Assemble the structured logger or the JavaScript tracer
 	var (
 		tracer           *tracers.Tracer
 		overrides        *ethparams.ChainConfig
 		jsonTracerConfig json.RawMessage
-		err              error
 		timeout          = defaultTraceTimeout
 	)
 
@@ -849,7 +845,11 @@ func (k *Keeper) traceTxWithMsg(
 	// Build EVM execution context
 	ctx = buildTraceCtx(ctx, msg.GasLimit, k.shouldPreserveKVGasConfig(ctx, msg.To))
 	stateDB := statedb.New(ctx, k, txConfig)
-	res, err := k.ApplyMessageWithConfig(ctx, stateDB, *msg, tracer.Hooks, commitMessage, false, cfg, txConfig, false, nil)
+	// Wrap any cosmos meter OOM (panic or return) in a gRPC status error.
+	defer wrapOutOfGasAsInternal(&err)
+	defer recoverMeterOOM(&err)
+	var res *types.MsgEthereumTxResponse
+	res, err = k.ApplyMessageWithConfig(ctx, stateDB, *msg, tracer.Hooks, commitMessage, false, cfg, txConfig, false, nil)
 	if err != nil {
 		return nil, 0, status.Error(codes.Internal, err.Error())
 	}
@@ -906,12 +906,45 @@ func (k Keeper) shouldPreserveKVGasConfig(ctx sdk.Context, to *common.Address) b
 
 	if k.erc20Keeper != nil {
 		_, found, err := k.erc20Keeper.GetERC20PrecompileInstance(ctx, *to)
-		if err == nil && found {
+		if err != nil {
+			k.Logger(ctx).Error("ERC20 precompile lookup failed, falling back to preserve=false", "address", to.Hex(), "error", err)
+			return false
+		}
+		if found {
 			return true
 		}
 	}
 
 	return false
+}
+
+// recoverMeterOOM is a deferred helper that converts a cosmos meter
+// ErrorOutOfGas panic into vm.ErrOutOfGas, other panics re-propagate.
+func recoverMeterOOM(err *error) {
+	if r := recover(); r != nil {
+		if _, ok := r.(storetypes.ErrorOutOfGas); ok {
+			*err = vm.ErrOutOfGas
+			return
+		}
+		panic(r)
+	}
+}
+
+// rewriteOutOfGasAsRaiseGas converts vm.ErrOutOfGas returns into
+// (vmError=true, rsp=nil, err=nil) so estimate binary search raises gas.
+func rewriteOutOfGasAsRaiseGas(vmError *bool, rsp **types.MsgEthereumTxResponse, err *error) {
+	if errors.Is(*err, vm.ErrOutOfGas) {
+		*vmError = true
+		*rsp = nil
+		*err = nil
+	}
+}
+
+// wrapOutOfGasAsInternal converts vm.ErrOutOfGas into a gRPC Internal error.
+func wrapOutOfGasAsInternal(err *error) {
+	if errors.Is(*err, vm.ErrOutOfGas) {
+		*err = status.Error(codes.Internal, (*err).Error())
+	}
 }
 
 // buildTraceCtx builds a context for simulating or tracing transactions.

--- a/x/vm/keeper/grpc_query.go
+++ b/x/vm/keeper/grpc_query.go
@@ -905,11 +905,15 @@ func (k Keeper) shouldPreserveKVGasConfig(ctx sdk.Context, to *common.Address) b
 	return false
 }
 
-// buildTraceCtx builds a context for simulating or tracing transactions.
-// KV gas configs are preserved only for native precompile recipients so
-// precompile keeper/store operations are charged consistently with real
-// execution; the cosmos-sdk meter is kept infinite — EVM-level gas accounting
-// is managed by the precompile's own RunSetup meter and contract.UseGas.
+// buildTraceCtx prepares a simulation/tracing ctx. The outer cosmos meter
+// stays infinite — EVM gas is accounted by each precompile's own RunSetup
+// meter and contract.UseGas.
+//
+// preserveKVGasConfig=true (msg.To is a native precompile) lets pre-precompile
+// cosmos-sdk ops accumulate into initialGas at precompile.RunSetup so binary
+// search reserves enough budget for precompile to enter. Non-precompile
+// recipients zero KV — otherwise an indirect sub-call would over-count the
+// caller's StateDB flush, which is free on real chain (ante zeroes KV).
 func buildTraceCtx(ctx sdk.Context, gasLimit uint64, preserveKVGasConfig bool) sdk.Context {
 	if !preserveKVGasConfig {
 		ctx = evmante.BuildEvmExecutionCtx(ctx)

--- a/x/vm/keeper/grpc_query.go
+++ b/x/vm/keeper/grpc_query.go
@@ -238,7 +238,11 @@ func (k Keeper) EthCall(c context.Context, req *types.EthCallRequest) (*types.Ms
 		}
 	}
 
-	ctx := sdk.UnwrapSDKContext(c)
+	// Align eth_call's KV gas accounting with deliverTx: clear KV/transient gas
+	// configs so EVM-internal cosmos-sdk store ops (e.g. precompile.FlushToCacheCtx)
+	// don't charge gas. Otherwise eth_call would report a stricter floor than
+	// real broadcast for txs reaching native precompiles.
+	ctx := evmante.BuildEvmExecutionCtx(sdk.UnwrapSDKContext(c))
 
 	var args types.TransactionArgs
 	err := json.Unmarshal(req.Args, &args)
@@ -401,13 +405,13 @@ func (k Keeper) EstimateGasInternal(c context.Context, req *types.EthCallRequest
 				return true, nil, err
 			}
 			// resetting the gasMeter after increasing the sequence to have an accurate gas estimation on EVM extensions transactions
-			tmpCtx = buildTraceCtx(tmpCtx, msg.GasLimit, k.shouldPreserveKVGasConfig(tmpCtx, msg.To))
+			tmpCtx = buildTraceCtx(tmpCtx, msg.GasLimit)
 		}
 		// pass false to not commit StateDB
 		stateDB := statedb.New(tmpCtx, &k, txConfig)
 		rsp, err = k.ApplyMessageWithConfig(tmpCtx, stateDB, *msg, nil, false, false, cfg, txConfig, false, nil)
 		if err != nil {
-			if errors.Is(err, core.ErrIntrinsicGas) || errors.Is(err, core.ErrFloorDataGas) || errors.Is(err, vm.ErrOutOfGas) {
+			if errors.Is(err, core.ErrIntrinsicGas) || errors.Is(err, core.ErrFloorDataGas) {
 				return true, nil, nil // Special case, raise gas limit
 			}
 			return true, nil, err // Bail out
@@ -542,7 +546,8 @@ func (k Keeper) TraceTx(c context.Context, req *types.QueryTraceTxRequest) (*typ
 	// need to reset gas meter per transaction to be consistent with tx execution
 	// and avoid stacking the gas used of every predecessor in the same gas meter
 
-	ctx = ctx.WithGasMeter(storetypes.NewGasMeter(maxPredecessorGas))
+	ctx = evmante.BuildEvmExecutionCtx(ctx).
+		WithGasMeter(storetypes.NewGasMeter(maxPredecessorGas))
 	for i, tx := range req.Predecessors {
 		ethTx := tx.AsTransaction()
 		msg, err := core.TransactionToMessage(ethTx, signer, cfg.BaseFee)
@@ -553,7 +558,7 @@ func (k Keeper) TraceTx(c context.Context, req *types.QueryTraceTxRequest) (*typ
 		txConfig.TxHash = ethTx.Hash()
 		txConfig.TxIndex = uint(i) //nolint:gosec // G115 // won't exceed uint64
 
-		ctx = buildTraceCtx(ctx, msg.GasLimit, k.shouldPreserveKVGasConfig(ctx, msg.To))
+		ctx = buildTraceCtx(ctx, msg.GasLimit)
 		// we ignore the error here. this endpoint, ideally, is called internally from the ETH backend, which will call this query
 		// using all previous txs in the trace transaction's block. some of those _could_ be invalid transactions.
 		stateDB := statedb.New(ctx, &k, txConfig)
@@ -833,7 +838,7 @@ func (k *Keeper) traceTxWithMsg(
 	}()
 
 	// Build EVM execution context
-	ctx = buildTraceCtx(ctx, msg.GasLimit, k.shouldPreserveKVGasConfig(ctx, msg.To))
+	ctx = buildTraceCtx(ctx, msg.GasLimit)
 	stateDB := statedb.New(ctx, k, txConfig)
 	var res *types.MsgEthereumTxResponse
 	res, err = k.ApplyMessageWithConfig(ctx, stateDB, *msg, tracer.Hooks, commitMessage, false, cfg, txConfig, false, nil)
@@ -881,42 +886,11 @@ func (k Keeper) Config(_ context.Context, _ *types.QueryConfigRequest) (*types.Q
 	return &types.QueryConfigResponse{Config: config}, nil
 }
 
-func (k Keeper) shouldPreserveKVGasConfig(ctx sdk.Context, to *common.Address) bool {
-	if to == nil {
-		return false
-	}
-
-	params := k.GetParams(ctx)
-	if k.IsAvailableStaticPrecompile(&params, *to) {
-		return true
-	}
-
-	if k.erc20Keeper != nil {
-		_, found, err := k.erc20Keeper.GetERC20PrecompileInstance(ctx, *to)
-		if err != nil {
-			k.Logger(ctx).Error("ERC20 precompile lookup failed, falling back to preserve=false", "address", to.Hex(), "error", err)
-			return false
-		}
-		if found {
-			return true
-		}
-	}
-
-	return false
-}
-
-// buildTraceCtx prepares a simulation/tracing ctx. The outer cosmos meter
-// stays infinite — EVM gas is accounted by each precompile's own RunSetup
-// meter and contract.UseGas.
-//
-// preserveKVGasConfig=true (msg.To is a native precompile) lets pre-precompile
-// cosmos-sdk ops accumulate into initialGas at precompile.RunSetup so binary
-// search reserves enough budget for precompile to enter. Non-precompile
-// recipients zero KV — otherwise an indirect sub-call would over-count the
-// caller's StateDB flush, which is free on real chain (ante zeroes KV).
-func buildTraceCtx(ctx sdk.Context, gasLimit uint64, preserveKVGasConfig bool) sdk.Context {
-	if !preserveKVGasConfig {
-		ctx = evmante.BuildEvmExecutionCtx(ctx)
-	}
-	return ctx.WithGasMeter(types.NewInfiniteGasMeterWithLimit(gasLimit))
+// buildTraceCtx prepares a simulation/tracing ctx. Clears KV/transient gas
+// configs (consistent with deliverTx's ante and EthCall) and installs an
+// outer infinite-with-limit meter. EVM gas accounting is handled by each
+// precompile's per-call inner meter and contract.UseGas.
+func buildTraceCtx(ctx sdk.Context, gasLimit uint64) sdk.Context {
+	return evmante.BuildEvmExecutionCtx(ctx).
+		WithGasMeter(types.NewInfiniteGasMeterWithLimit(gasLimit))
 }

--- a/x/vm/keeper/grpc_query.go
+++ b/x/vm/keeper/grpc_query.go
@@ -542,8 +542,7 @@ func (k Keeper) TraceTx(c context.Context, req *types.QueryTraceTxRequest) (*typ
 	// need to reset gas meter per transaction to be consistent with tx execution
 	// and avoid stacking the gas used of every predecessor in the same gas meter
 
-	ctx = evmante.BuildEvmExecutionCtx(ctx).
-		WithGasMeter(storetypes.NewGasMeter(maxPredecessorGas))
+	ctx = ctx.WithGasMeter(storetypes.NewGasMeter(maxPredecessorGas))
 	for i, tx := range req.Predecessors {
 		ethTx := tx.AsTransaction()
 		msg, err := core.TransactionToMessage(ethTx, signer, cfg.BaseFee)

--- a/x/vm/keeper/grpc_query.go
+++ b/x/vm/keeper/grpc_query.go
@@ -379,6 +379,18 @@ func (k Keeper) EstimateGasInternal(c context.Context, req *types.EthCallRequest
 
 	// create a helper to check if a gas allowance results in an executable transaction
 	executable := func(gas uint64) (vmError bool, rsp *types.MsgEthereumTxResponse, err error) {
+		// Treat cosmos meter OOM panics (preserve-KvGasConfig mode) as a
+		// "raise gas" signal so the binary search continues.
+		defer func() {
+			if r := recover(); r != nil {
+				if _, ok := r.(storetypes.ErrorOutOfGas); ok {
+					vmError, rsp, err = true, nil, nil
+					return
+				}
+				panic(r)
+			}
+		}()
+
 		// update the message with the new gas value
 		msg.GasLimit = gas
 
@@ -401,7 +413,7 @@ func (k Keeper) EstimateGasInternal(c context.Context, req *types.EthCallRequest
 				return true, nil, err
 			}
 			// resetting the gasMeter after increasing the sequence to have an accurate gas estimation on EVM extensions transactions
-			tmpCtx = buildTraceCtx(tmpCtx, msg.GasLimit)
+			tmpCtx = buildTraceCtx(tmpCtx, msg.GasLimit, k.shouldPreserveKVGasConfig(tmpCtx, msg.To))
 		}
 		// pass false to not commit StateDB
 		stateDB := statedb.New(tmpCtx, &k, txConfig)
@@ -554,7 +566,7 @@ func (k Keeper) TraceTx(c context.Context, req *types.QueryTraceTxRequest) (*typ
 		txConfig.TxHash = ethTx.Hash()
 		txConfig.TxIndex = uint(i) //nolint:gosec // G115 // won't exceed uint64
 
-		ctx = buildTraceCtx(ctx, msg.GasLimit)
+		ctx = buildTraceCtx(ctx, msg.GasLimit, k.shouldPreserveKVGasConfig(ctx, msg.To))
 		// we ignore the error here. this endpoint, ideally, is called internally from the ETH backend, which will call this query
 		// using all previous txs in the trace transaction's block. some of those _could_ be invalid transactions.
 		stateDB := statedb.New(ctx, &k, txConfig)
@@ -835,7 +847,7 @@ func (k *Keeper) traceTxWithMsg(
 	}()
 
 	// Build EVM execution context
-	ctx = buildTraceCtx(ctx, msg.GasLimit)
+	ctx = buildTraceCtx(ctx, msg.GasLimit, k.shouldPreserveKVGasConfig(ctx, msg.To))
 	stateDB := statedb.New(ctx, k, txConfig)
 	res, err := k.ApplyMessageWithConfig(ctx, stateDB, *msg, tracer.Hooks, commitMessage, false, cfg, txConfig, false, nil)
 	if err != nil {
@@ -882,10 +894,34 @@ func (k Keeper) Config(_ context.Context, _ *types.QueryConfigRequest) (*types.Q
 	return &types.QueryConfigResponse{Config: config}, nil
 }
 
-// buildTraceCtx builds a context for simulating or tracing transactions by:
-// 1. assigning a new infinite gas meter with the provided gasLimit
-// 2. calling BuildEvmExecutionCtx to set up gas configs consistent with Ethereum transaction execution.
-func buildTraceCtx(ctx sdk.Context, gasLimit uint64) sdk.Context {
-	return evmante.BuildEvmExecutionCtx(ctx).
-		WithGasMeter(types.NewInfiniteGasMeterWithLimit(gasLimit))
+func (k Keeper) shouldPreserveKVGasConfig(ctx sdk.Context, to *common.Address) bool {
+	if to == nil {
+		return false
+	}
+
+	params := k.GetParams(ctx)
+	if k.IsAvailableStaticPrecompile(&params, *to) {
+		return true
+	}
+
+	if k.erc20Keeper != nil {
+		_, found, err := k.erc20Keeper.GetERC20PrecompileInstance(ctx, *to)
+		if err == nil && found {
+			return true
+		}
+	}
+
+	return false
+}
+
+// buildTraceCtx builds a context for simulating or tracing transactions.
+// It always installs a finite gas meter at gasLimit so under-gassed iterations
+// fail fast. KV gas configs are preserved only for native precompile recipients
+// so precompile keeper/store operations are charged like eth_call.
+func buildTraceCtx(ctx sdk.Context, gasLimit uint64, preserveKVGasConfig bool) sdk.Context {
+	if !preserveKVGasConfig {
+		ctx = evmante.BuildEvmExecutionCtx(ctx)
+	}
+
+	return ctx.WithGasMeter(storetypes.NewGasMeter(gasLimit))
 }

--- a/x/vm/keeper/grpc_query.go
+++ b/x/vm/keeper/grpc_query.go
@@ -379,10 +379,6 @@ func (k Keeper) EstimateGasInternal(c context.Context, req *types.EthCallRequest
 
 	// create a helper to check if a gas allowance results in an executable transaction
 	executable := func(gas uint64) (vmError bool, rsp *types.MsgEthereumTxResponse, err error) {
-		// Convert cosmos meter OOM (panic or return) into a "raise gas" signal.
-		defer rewriteOutOfGasAsRaiseGas(&vmError, &rsp, &err)
-		defer recoverMeterOOM(&err)
-
 		// update the message with the new gas value
 		msg.GasLimit = gas
 
@@ -562,16 +558,11 @@ func (k Keeper) TraceTx(c context.Context, req *types.QueryTraceTxRequest) (*typ
 		// we ignore the error here. this endpoint, ideally, is called internally from the ETH backend, which will call this query
 		// using all previous txs in the trace transaction's block. some of those _could_ be invalid transactions.
 		stateDB := statedb.New(ctx, &k, txConfig)
-		// Closure-scoped recover so one predecessor's OOM doesn't abort the trace.
-		func() {
-			var applyErr error
-			defer recoverMeterOOM(&applyErr)
-			rsp, _ := k.ApplyMessageWithConfig(ctx, stateDB, *msg, nil, true, false, cfg, txConfig, false, nil)
-			if applyErr == nil && rsp != nil {
-				ctx.GasMeter().ConsumeGas(rsp.GasUsed, "evm predecessor tx")
-				txConfig.LogIndex += uint(len(rsp.Logs))
-			}
-		}()
+		rsp, _ := k.ApplyMessageWithConfig(ctx, stateDB, *msg, nil, true, false, cfg, txConfig, false, nil)
+		if rsp != nil {
+			ctx.GasMeter().ConsumeGas(rsp.GasUsed, "evm predecessor tx")
+			txConfig.LogIndex += uint(len(rsp.Logs))
+		}
 	}
 
 	tx := req.Msg.AsTransaction()
@@ -845,9 +836,6 @@ func (k *Keeper) traceTxWithMsg(
 	// Build EVM execution context
 	ctx = buildTraceCtx(ctx, msg.GasLimit, k.shouldPreserveKVGasConfig(ctx, msg.To))
 	stateDB := statedb.New(ctx, k, txConfig)
-	// Wrap any cosmos meter OOM (panic or return) in a gRPC status error.
-	defer wrapOutOfGasAsInternal(&err)
-	defer recoverMeterOOM(&err)
 	var res *types.MsgEthereumTxResponse
 	res, err = k.ApplyMessageWithConfig(ctx, stateDB, *msg, tracer.Hooks, commitMessage, false, cfg, txConfig, false, nil)
 	if err != nil {
@@ -918,43 +906,14 @@ func (k Keeper) shouldPreserveKVGasConfig(ctx sdk.Context, to *common.Address) b
 	return false
 }
 
-// recoverMeterOOM is a deferred helper that converts a cosmos meter
-// ErrorOutOfGas panic into vm.ErrOutOfGas, other panics re-propagate.
-func recoverMeterOOM(err *error) {
-	if r := recover(); r != nil {
-		if _, ok := r.(storetypes.ErrorOutOfGas); ok {
-			*err = vm.ErrOutOfGas
-			return
-		}
-		panic(r)
-	}
-}
-
-// rewriteOutOfGasAsRaiseGas converts vm.ErrOutOfGas returns into
-// (vmError=true, rsp=nil, err=nil) so estimate binary search raises gas.
-func rewriteOutOfGasAsRaiseGas(vmError *bool, rsp **types.MsgEthereumTxResponse, err *error) {
-	if errors.Is(*err, vm.ErrOutOfGas) {
-		*vmError = true
-		*rsp = nil
-		*err = nil
-	}
-}
-
-// wrapOutOfGasAsInternal converts vm.ErrOutOfGas into a gRPC Internal error.
-func wrapOutOfGasAsInternal(err *error) {
-	if errors.Is(*err, vm.ErrOutOfGas) {
-		*err = status.Error(codes.Internal, (*err).Error())
-	}
-}
-
 // buildTraceCtx builds a context for simulating or tracing transactions.
-// It always installs a finite gas meter at gasLimit so under-gassed iterations
-// fail fast. KV gas configs are preserved only for native precompile recipients
-// so precompile keeper/store operations are charged like eth_call.
+// KV gas configs are preserved only for native precompile recipients so
+// precompile keeper/store operations are charged consistently with real
+// execution; the cosmos-sdk meter is kept infinite — EVM-level gas accounting
+// is managed by the precompile's own RunSetup meter and contract.UseGas.
 func buildTraceCtx(ctx sdk.Context, gasLimit uint64, preserveKVGasConfig bool) sdk.Context {
 	if !preserveKVGasConfig {
 		ctx = evmante.BuildEvmExecutionCtx(ctx)
 	}
-
-	return ctx.WithGasMeter(storetypes.NewGasMeter(gasLimit))
+	return ctx.WithGasMeter(types.NewInfiniteGasMeterWithLimit(gasLimit))
 }

--- a/x/vm/keeper/grpc_query.go
+++ b/x/vm/keeper/grpc_query.go
@@ -764,12 +764,13 @@ func (k *Keeper) traceTxWithMsg(
 	msg *core.Message,
 	traceConfig *types.TraceConfig,
 	commitMessage bool,
-) (_ *interface{}, _ uint, err error) {
+) (*interface{}, uint, error) {
 	// Assemble the structured logger or the JavaScript tracer
 	var (
 		tracer           *tracers.Tracer
 		overrides        *ethparams.ChainConfig
 		jsonTracerConfig json.RawMessage
+		err              error
 		timeout          = defaultTraceTimeout
 	)
 
@@ -840,8 +841,7 @@ func (k *Keeper) traceTxWithMsg(
 	// Build EVM execution context
 	ctx = buildTraceCtx(ctx, msg.GasLimit)
 	stateDB := statedb.New(ctx, k, txConfig)
-	var res *types.MsgEthereumTxResponse
-	res, err = k.ApplyMessageWithConfig(ctx, stateDB, *msg, tracer.Hooks, commitMessage, false, cfg, txConfig, false, nil)
+	res, err := k.ApplyMessageWithConfig(ctx, stateDB, *msg, tracer.Hooks, commitMessage, false, cfg, txConfig, false, nil)
 	if err != nil {
 		return nil, 0, status.Error(codes.Internal, err.Error())
 	}
@@ -886,10 +886,9 @@ func (k Keeper) Config(_ context.Context, _ *types.QueryConfigRequest) (*types.Q
 	return &types.QueryConfigResponse{Config: config}, nil
 }
 
-// buildTraceCtx prepares a simulation/tracing ctx. Clears KV/transient gas
-// configs (consistent with deliverTx's ante and EthCall) and installs an
-// outer infinite-with-limit meter. EVM gas accounting is handled by each
-// precompile's per-call inner meter and contract.UseGas.
+// buildTraceCtx builds a context for simulating or tracing transactions by:
+// 1. assigning a new infinite gas meter with the provided gasLimit
+// 2. calling BuildEvmExecutionCtx to set up gas configs consistent with Ethereum transaction execution.
 func buildTraceCtx(ctx sdk.Context, gasLimit uint64) sdk.Context {
 	return evmante.BuildEvmExecutionCtx(ctx).
 		WithGasMeter(types.NewInfiniteGasMeterWithLimit(gasLimit))

--- a/x/vm/keeper/grpc_query_test.go
+++ b/x/vm/keeper/grpc_query_test.go
@@ -1,0 +1,48 @@
+package keeper
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	storetypes "github.com/cosmos/cosmos-sdk/store/v2/types"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+)
+
+func TestBuildTraceCtxEnforcesGasLimit(t *testing.T) {
+	const gasLimit = uint64(1_000_000)
+	meter := buildTraceCtx(sdk.Context{}, gasLimit, false).GasMeter()
+	require.Equal(t, gasLimit, meter.Limit())
+	require.NotPanics(t, func() { meter.ConsumeGas(gasLimit-1, "below") })
+
+	defer func() {
+		_, isOutOfGas := recover().(storetypes.ErrorOutOfGas)
+		require.True(t, isOutOfGas, "expected ErrorOutOfGas past limit")
+	}()
+
+	meter.ConsumeGas(2, "exceeds")
+}
+
+// buildTraceCtx must zero KV gas configs for pure-EVM simulation so SLOAD/SSTORE
+// gas accounting remains opcode-driven and does not consume KV gas.
+func TestBuildTraceCtxZeroesKVGasConfigWhenNotPreserving(t *testing.T) {
+	parent := sdk.Context{}.
+		WithKVGasConfig(storetypes.KVGasConfig()).
+		WithTransientKVGasConfig(storetypes.TransientGasConfig())
+	traceCtx := buildTraceCtx(parent, 1_000_000, false)
+	require.Equal(t, storetypes.GasConfig{}, traceCtx.KVGasConfig())
+	require.Equal(t, storetypes.GasConfig{}, traceCtx.TransientKVGasConfig())
+}
+
+// buildTraceCtx must preserve KV gas configs for native precompile recipients
+// so keeper/store operations are charged during estimation and tracing.
+func TestBuildTraceCtxPreservesKVGasConfigWhenRequested(t *testing.T) {
+	kv := storetypes.KVGasConfig()
+	transient := storetypes.TransientGasConfig()
+	parent := sdk.Context{}.
+		WithKVGasConfig(kv).
+		WithTransientKVGasConfig(transient)
+	traceCtx := buildTraceCtx(parent, 1_000_000, true)
+	require.Equal(t, kv, traceCtx.KVGasConfig())
+	require.Equal(t, transient, traceCtx.TransientKVGasConfig())
+}

--- a/x/vm/keeper/grpc_query_test.go
+++ b/x/vm/keeper/grpc_query_test.go
@@ -10,26 +10,16 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 )
 
-// buildTraceCtx must zero KV gas configs for pure-EVM simulation so SLOAD/SSTORE
-// gas accounting remains opcode-driven and does not consume KV gas.
-func TestBuildTraceCtxZeroesKVGasConfigWhenNotPreserving(t *testing.T) {
+// buildTraceCtx must zero KV gas configs so simulation matches deliverTx
+// (whose ante also zeroes KV via BuildEvmExecutionCtx). SLOAD/SSTORE gas
+// accounting then remains opcode-driven and does not consume KV gas, and
+// pre-precompile cosmos-sdk store ops (e.g. stateDB.FlushToCacheCtx) are
+// free — same as on real chain.
+func TestBuildTraceCtxZeroesKVGasConfig(t *testing.T) {
 	parent := sdk.Context{}.
 		WithKVGasConfig(storetypes.KVGasConfig()).
 		WithTransientKVGasConfig(storetypes.TransientGasConfig())
-	traceCtx := buildTraceCtx(parent, 1_000_000, false)
+	traceCtx := buildTraceCtx(parent, 1_000_000)
 	require.Equal(t, storetypes.GasConfig{}, traceCtx.KVGasConfig())
 	require.Equal(t, storetypes.GasConfig{}, traceCtx.TransientKVGasConfig())
-}
-
-// buildTraceCtx must preserve KV gas configs for native precompile recipients
-// so keeper/store operations are charged during estimation and tracing.
-func TestBuildTraceCtxPreservesKVGasConfigWhenRequested(t *testing.T) {
-	kv := storetypes.KVGasConfig()
-	transient := storetypes.TransientGasConfig()
-	parent := sdk.Context{}.
-		WithKVGasConfig(kv).
-		WithTransientKVGasConfig(transient)
-	traceCtx := buildTraceCtx(parent, 1_000_000, true)
-	require.Equal(t, kv, traceCtx.KVGasConfig())
-	require.Equal(t, transient, traceCtx.TransientKVGasConfig())
 }

--- a/x/vm/keeper/grpc_query_test.go
+++ b/x/vm/keeper/grpc_query_test.go
@@ -1,34 +1,14 @@
 package keeper
 
 import (
-	"errors"
 	"testing"
 
-	"github.com/ethereum/go-ethereum/core/vm"
 	"github.com/stretchr/testify/require"
-	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/status"
-
-	vmtypes "github.com/cosmos/evm/x/vm/types"
 
 	storetypes "cosmossdk.io/store/types"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
 )
-
-func TestBuildTraceCtxEnforcesGasLimit(t *testing.T) {
-	const gasLimit = uint64(1_000_000)
-	meter := buildTraceCtx(sdk.Context{}, gasLimit, false).GasMeter()
-	require.Equal(t, gasLimit, meter.Limit())
-	require.NotPanics(t, func() { meter.ConsumeGas(gasLimit-1, "below") })
-
-	defer func() {
-		_, isOutOfGas := recover().(storetypes.ErrorOutOfGas)
-		require.True(t, isOutOfGas, "expected ErrorOutOfGas past limit")
-	}()
-
-	meter.ConsumeGas(2, "exceeds")
-}
 
 // buildTraceCtx must zero KV gas configs for pure-EVM simulation so SLOAD/SSTORE
 // gas accounting remains opcode-driven and does not consume KV gas.
@@ -52,89 +32,4 @@ func TestBuildTraceCtxPreservesKVGasConfigWhenRequested(t *testing.T) {
 	traceCtx := buildTraceCtx(parent, 1_000_000, true)
 	require.Equal(t, kv, traceCtx.KVGasConfig())
 	require.Equal(t, transient, traceCtx.TransientKVGasConfig())
-}
-
-// recoverMeterOOM converts cosmos meter OOM panics to vm.ErrOutOfGas;
-// other paths are untouched.
-func TestRecoverMeterOOM(t *testing.T) {
-	got := func() (err error) {
-		defer recoverMeterOOM(&err)
-		panic(storetypes.ErrorOutOfGas{Descriptor: "ReadFlat"})
-	}()
-	require.True(t, errors.Is(got, vm.ErrOutOfGas), "expected vm.ErrOutOfGas, got %v", got)
-
-	got = func() (err error) {
-		defer recoverMeterOOM(&err)
-		return nil
-	}()
-	require.NoError(t, got)
-
-	sentinel := errors.New("sentinel")
-	got = func() (err error) {
-		defer recoverMeterOOM(&err)
-		return sentinel
-	}()
-	require.Same(t, sentinel, got)
-
-	require.PanicsWithValue(t, "boom", func() {
-		var err error
-		defer recoverMeterOOM(&err)
-		panic("boom")
-	})
-}
-
-// executable's two-defer pattern converts a cosmos meter OOM panic into
-// (true, nil, nil) so the binary search treats it as "raise gas".
-func TestExecutablePatternConvertsOOMToRaiseGas(t *testing.T) {
-	run := func(shouldPanic bool) (vmError bool, rsp *vmtypes.MsgEthereumTxResponse, err error) {
-		defer rewriteOutOfGasAsRaiseGas(&vmError, &rsp, &err)
-		defer recoverMeterOOM(&err)
-		if shouldPanic {
-			panic(storetypes.ErrorOutOfGas{Descriptor: "ReadFlat"})
-		}
-		return false, &vmtypes.MsgEthereumTxResponse{}, nil
-	}
-
-	vmError, rsp, err := run(true)
-	require.True(t, vmError)
-	require.Nil(t, rsp)
-	require.NoError(t, err)
-
-	vmError, rsp, err = run(false)
-	require.False(t, vmError)
-	require.NotNil(t, rsp)
-	require.NoError(t, err)
-}
-
-func TestRewriteOutOfGasAsRaiseGas(t *testing.T) {
-	vmError := false
-	rsp := &vmtypes.MsgEthereumTxResponse{}
-	err := vm.ErrOutOfGas
-
-	rewriteOutOfGasAsRaiseGas(&vmError, &rsp, &err)
-
-	require.True(t, vmError)
-	require.Nil(t, rsp)
-	require.NoError(t, err)
-
-	vmError = false
-	rsp = &vmtypes.MsgEthereumTxResponse{}
-	err = errors.New("other")
-
-	rewriteOutOfGasAsRaiseGas(&vmError, &rsp, &err)
-
-	require.False(t, vmError)
-	require.NotNil(t, rsp)
-	require.EqualError(t, err, "other")
-}
-
-func TestWrapOutOfGasAsInternal(t *testing.T) {
-	err := vm.ErrOutOfGas
-	wrapOutOfGasAsInternal(&err)
-	require.Equal(t, codes.Internal, status.Code(err))
-	require.Contains(t, err.Error(), vm.ErrOutOfGas.Error())
-
-	err = errors.New("other")
-	wrapOutOfGasAsInternal(&err)
-	require.EqualError(t, err, "other")
 }

--- a/x/vm/keeper/grpc_query_test.go
+++ b/x/vm/keeper/grpc_query_test.go
@@ -1,11 +1,18 @@
 package keeper
 
 import (
+	"errors"
 	"testing"
 
+	"github.com/ethereum/go-ethereum/core/vm"
 	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	vmtypes "github.com/cosmos/evm/x/vm/types"
 
 	storetypes "cosmossdk.io/store/types"
+
 	sdk "github.com/cosmos/cosmos-sdk/types"
 )
 
@@ -45,4 +52,89 @@ func TestBuildTraceCtxPreservesKVGasConfigWhenRequested(t *testing.T) {
 	traceCtx := buildTraceCtx(parent, 1_000_000, true)
 	require.Equal(t, kv, traceCtx.KVGasConfig())
 	require.Equal(t, transient, traceCtx.TransientKVGasConfig())
+}
+
+// recoverMeterOOM converts cosmos meter OOM panics to vm.ErrOutOfGas;
+// other paths are untouched.
+func TestRecoverMeterOOM(t *testing.T) {
+	got := func() (err error) {
+		defer recoverMeterOOM(&err)
+		panic(storetypes.ErrorOutOfGas{Descriptor: "ReadFlat"})
+	}()
+	require.True(t, errors.Is(got, vm.ErrOutOfGas), "expected vm.ErrOutOfGas, got %v", got)
+
+	got = func() (err error) {
+		defer recoverMeterOOM(&err)
+		return nil
+	}()
+	require.NoError(t, got)
+
+	sentinel := errors.New("sentinel")
+	got = func() (err error) {
+		defer recoverMeterOOM(&err)
+		return sentinel
+	}()
+	require.Same(t, sentinel, got)
+
+	require.PanicsWithValue(t, "boom", func() {
+		var err error
+		defer recoverMeterOOM(&err)
+		panic("boom")
+	})
+}
+
+// executable's two-defer pattern converts a cosmos meter OOM panic into
+// (true, nil, nil) so the binary search treats it as "raise gas".
+func TestExecutablePatternConvertsOOMToRaiseGas(t *testing.T) {
+	run := func(shouldPanic bool) (vmError bool, rsp *vmtypes.MsgEthereumTxResponse, err error) {
+		defer rewriteOutOfGasAsRaiseGas(&vmError, &rsp, &err)
+		defer recoverMeterOOM(&err)
+		if shouldPanic {
+			panic(storetypes.ErrorOutOfGas{Descriptor: "ReadFlat"})
+		}
+		return false, &vmtypes.MsgEthereumTxResponse{}, nil
+	}
+
+	vmError, rsp, err := run(true)
+	require.True(t, vmError)
+	require.Nil(t, rsp)
+	require.NoError(t, err)
+
+	vmError, rsp, err = run(false)
+	require.False(t, vmError)
+	require.NotNil(t, rsp)
+	require.NoError(t, err)
+}
+
+func TestRewriteOutOfGasAsRaiseGas(t *testing.T) {
+	vmError := false
+	rsp := &vmtypes.MsgEthereumTxResponse{}
+	err := vm.ErrOutOfGas
+
+	rewriteOutOfGasAsRaiseGas(&vmError, &rsp, &err)
+
+	require.True(t, vmError)
+	require.Nil(t, rsp)
+	require.NoError(t, err)
+
+	vmError = false
+	rsp = &vmtypes.MsgEthereumTxResponse{}
+	err = errors.New("other")
+
+	rewriteOutOfGasAsRaiseGas(&vmError, &rsp, &err)
+
+	require.False(t, vmError)
+	require.NotNil(t, rsp)
+	require.EqualError(t, err, "other")
+}
+
+func TestWrapOutOfGasAsInternal(t *testing.T) {
+	err := vm.ErrOutOfGas
+	wrapOutOfGasAsInternal(&err)
+	require.Equal(t, codes.Internal, status.Code(err))
+	require.Contains(t, err.Error(), vm.ErrOutOfGas.Error())
+
+	err = errors.New("other")
+	wrapOutOfGasAsInternal(&err)
+	require.EqualError(t, err, "other")
 }

--- a/x/vm/keeper/grpc_query_test.go
+++ b/x/vm/keeper/grpc_query_test.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	storetypes "github.com/cosmos/cosmos-sdk/store/v2/types"
+	storetypes "cosmossdk.io/store/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 )
 

--- a/x/vm/statedb/statedb.go
+++ b/x/vm/statedb/statedb.go
@@ -438,7 +438,7 @@ func (s *StateDB) setStateObject(object *stateObject) {
 // to the precompile call.
 func (s *StateDB) AddPrecompileFn(snapshot int) error {
 	// Capture events before the precompile call
-	var prevEvents sdk.Events = s.cacheCtx.EventManager().Events()
+	prevEvents := s.cacheCtx.EventManager().Events()
 
 	s.journal.append(precompileCallChange{
 		snapshot:                snapshot,


### PR DESCRIPTION
# Description

align eth_call's KV gas accounting with deliverTx so it stops rejecting valid estimateGas results for native precompile txs

<!-- Please keep your PR as draft until it's ready for review -->

<!-- Pull requests that sit inactive for longer than 30 days will be closed.  -->

for test [info](https://github.com/MANTRA-Chain/mantrachain-e2e/pull/170/changes)

---

## Author Checklist

**All** items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.

I have...

- [ ] tackled an existing issue or discussed with a team member
- [ ] left instructions on how to review the changes
- [ ] targeted the `main` branch
