### PR TITLE
fix: harden statedb balance and event amount handling (backport #1176…

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,12 @@ src="repo_header.svg"
 alt="Cosmos EVM - A plug-and-play solution that adds EVM compatibility and customizability to your chain"
 />
 
+## What is Cosmos EVM?
+
+Cosmos EVM is a plug-and-play solution that adds EVM compatibility and customizability to your Cosmos SDK chain. Cosmos EVM is used by Ondo, Mezo, Mantra, XRP sidechain, Telegram Application Chain (TAC), Stable, and others. Cosmos EVM equips Cosmos chains with complete Ethereum capabilities: Solidity smart contracts, Ethereum JSON-RPC, native support for the EVM wallet/token/user experience, and access to the entire Ethereum developer ecosystem. Its precompiles and extensions allow developers to leverage modules like [IBC](https://github.com/cosmos/ibc-go) with EVM and get native ERC-20 support for tokens on Cosmos. 
+
+Cosmos EVM is customizable for your business use case, chain architecture, and performance needs.
+
 **Please note**: This repo is undergoing changes while the code is being audited and tested. For the time being we will
 be making v0.x releases. Some breaking changes might occur. Cosmos Labs will only mark the Cosmos EVM repository as stable with a v1
 release after the audit, key stability features and benchmarking are completed.

--- a/precompiles/common/balance_handler_test.go
+++ b/precompiles/common/balance_handler_test.go
@@ -98,12 +98,14 @@ func TestParseAddress(t *testing.T) {
 func TestParseAmount(t *testing.T) {
 	testCases := []struct {
 		name     string
+		chainID  testconstants.ChainID
 		maleate  func() sdk.Event
 		expAmt   *uint256.Int
 		expError bool
 	}{
 		{
-			name: "valid amount",
+			name:    "valid amount",
+			chainID: testconstants.ExampleChainID,
 			maleate: func() sdk.Event {
 				coinStr := sdk.NewCoins(sdk.NewInt64Coin(evmtypes.GetEVMCoinDenom(), 5)).String()
 				return sdk.NewEvent("bank", sdk.NewAttribute(sdk.AttributeKeyAmount, coinStr))
@@ -111,14 +113,55 @@ func TestParseAmount(t *testing.T) {
 			expAmt: uint256.NewInt(5),
 		},
 		{
-			name: "missing amount",
+			name:    "unrelated denom is ignored",
+			chainID: testconstants.ExampleChainID,
+			maleate: func() sdk.Event {
+				coinStr := sdk.NewCoins(sdk.NewInt64Coin("foobar", 7)).String()
+				return sdk.NewEvent("bank", sdk.NewAttribute(sdk.AttributeKeyAmount, coinStr))
+			},
+			expAmt: uint256.NewInt(0),
+		},
+		{
+			name:    "base denom is scaled to 18 decimals",
+			chainID: testconstants.SixDecimalsChainID,
+			maleate: func() sdk.Event {
+				coinStr := sdk.NewCoins(sdk.NewInt64Coin(evmtypes.GetEVMCoinDenom(), 100)).String()
+				return sdk.NewEvent("bank", sdk.NewAttribute(sdk.AttributeKeyAmount, coinStr))
+			},
+			expAmt: uint256.NewInt(100_000_000_000_000),
+		},
+		{
+			name:    "extended denom is taken as is",
+			chainID: testconstants.SixDecimalsChainID,
+			maleate: func() sdk.Event {
+				coinStr := sdk.NewCoins(sdk.NewInt64Coin(evmtypes.GetEVMCoinExtendedDenom(), 500)).String()
+				return sdk.NewEvent("bank", sdk.NewAttribute(sdk.AttributeKeyAmount, coinStr))
+			},
+			expAmt: uint256.NewInt(500),
+		},
+		{
+			name:    "base and extended denoms are summed",
+			chainID: testconstants.SixDecimalsChainID,
+			maleate: func() sdk.Event {
+				coinStr := sdk.NewCoins(
+					sdk.NewInt64Coin(evmtypes.GetEVMCoinDenom(), 100),
+					sdk.NewInt64Coin(evmtypes.GetEVMCoinExtendedDenom(), 500),
+				).String()
+				return sdk.NewEvent("bank", sdk.NewAttribute(sdk.AttributeKeyAmount, coinStr))
+			},
+			expAmt: uint256.NewInt(100_000_000_000_500),
+		},
+		{
+			name:    "missing amount",
+			chainID: testconstants.ExampleChainID,
 			maleate: func() sdk.Event {
 				return sdk.NewEvent("bank")
 			},
 			expError: true,
 		},
 		{
-			name: "invalid coins",
+			name:    "invalid coins",
+			chainID: testconstants.ExampleChainID,
 			maleate: func() sdk.Event {
 				return sdk.NewEvent("bank", sdk.NewAttribute(sdk.AttributeKeyAmount, "invalid"))
 			},
@@ -128,7 +171,9 @@ func TestParseAmount(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			setupBalanceHandlerTest(t)
+			configurator := evmtypes.NewEVMConfigurator()
+			configurator.ResetTestConfig()
+			require.NoError(t, configurator.WithEVMCoinInfo(testconstants.ExampleChainCoinInfo[tc.chainID]).Configure())
 
 			amt, err := cmn.ParseAmount(tc.maleate())
 			if tc.expError {
@@ -137,7 +182,7 @@ func TestParseAmount(t *testing.T) {
 			}
 
 			require.NoError(t, err)
-			require.True(t, amt.Eq(tc.expAmt))
+			require.Equal(t, tc.expAmt.String(), amt.String())
 		})
 	}
 }

--- a/precompiles/common/utils.go
+++ b/precompiles/common/utils.go
@@ -42,8 +42,14 @@ func ParseAmount(event sdk.Event) (*uint256.Int, error) {
 		return nil, fmt.Errorf("failed to parse coins from %q: %w", amountAttr.Value, err)
 	}
 
-	amountBigInt := amountCoins.AmountOf(evmtypes.GetEVMCoinDenom()).BigInt()
-	amount, err := utils.Uint256FromBigInt(evmtypes.ConvertAmountTo18DecimalsBigInt(amountBigInt))
+	baseAmount := amountCoins.AmountOf(evmtypes.GetEVMCoinDenom()).BigInt()
+	amountBigInt := evmtypes.ConvertAmountTo18DecimalsBigInt(baseAmount)
+	if evmtypes.GetEVMCoinExtendedDenom() != evmtypes.GetEVMCoinDenom() {
+		extendedAmount := amountCoins.AmountOf(evmtypes.GetEVMCoinExtendedDenom()).BigInt()
+		amountBigInt = new(big.Int).Add(amountBigInt, extendedAmount)
+	}
+
+	amount, err := utils.Uint256FromBigInt(amountBigInt)
 	if err != nil {
 		return nil, fmt.Errorf("failed to convert coin amount to Uint256: %w", err)
 	}

--- a/x/vm/statedb/state_object.go
+++ b/x/vm/statedb/state_object.go
@@ -2,6 +2,7 @@ package statedb
 
 import (
 	"bytes"
+	"fmt"
 	"sort"
 
 	"github.com/ethereum/go-ethereum/common"
@@ -122,7 +123,16 @@ func (s *stateObject) SubBalance(amount *uint256.Int) uint256.Int {
 	if amount.IsZero() {
 		return *(s.Balance())
 	}
-	return s.SetBalance(new(uint256.Int).Sub(s.Balance(), amount))
+	balance := s.Balance()
+	if balance.Lt(amount) {
+		panic(fmt.Sprintf(
+			"state balance underflow for %s: have=%s sub=%s",
+			s.address.Hex(),
+			balance.String(),
+			amount.String(),
+		))
+	}
+	return s.SetBalance(new(uint256.Int).Sub(balance, amount))
 }
 
 // SetBalance updates account balance.

--- a/x/vm/statedb/statedb_test.go
+++ b/x/vm/statedb/statedb_test.go
@@ -240,7 +240,6 @@ func (suite *StateDBTestSuite) TestDBError() {
 }
 
 func (suite *StateDBTestSuite) TestBalance() {
-	// NOTE: no need to test overflow/underflow, that is guaranteed by evm implementation.
 	testCases := []struct {
 		name       string
 		malleate   func(*statedb.StateDB)
@@ -277,6 +276,16 @@ func (suite *StateDBTestSuite) TestBalance() {
 			suite.Require().Equal(tc.expBalance, keeper.GetAccount(ctx, address).Balance)
 		})
 	}
+}
+
+func (suite *StateDBTestSuite) TestSubBalanceUnderflowPanics() {
+	db := statedb.New(sdk.Context{}.WithEventManager(sdk.NewEventManager()), mocks.NewEVMKeeper(), emptyTxConfig)
+	db.AddBalance(address, uint256.NewInt(1), tracing.BalanceChangeUnspecified)
+
+	expectedPanic := fmt.Sprintf("state balance underflow for %s: have=%s sub=%s", address.Hex(), "1", "2")
+	suite.Require().PanicsWithValue(expectedPanic, func() {
+		db.SubBalance(address, uint256.NewInt(2), tracing.BalanceChangeUnspecified)
+	})
 }
 
 func (suite *StateDBTestSuite) TestState() {


### PR DESCRIPTION
…) (#1253)

* fix: harden statedb balance and event amount handling (#1176)

* fix: harden statedb balance and event amount handling

Guard StateDB balance subtraction against underflow and make precompile balance-event parsing denom-aware for base vs extended denom paths. Also add regression tests and document that only 18-decimal EVM gas-token chains are supported.



* fix(vm): enforce 18-decimal coin configuration

Reject non-18 decimal EVM coin configs in both runtime and test configurators, align affected tests, and temporarily exclude precisebank packages from root unit-test targets until precisebank removal lands.



* chore: remove obsolete precisebank test package filters

Now that contrib/x/precisebank is removed on main, package selection no longer needs explicit exclusions and can rely on the standard simulation/e2e filters.



* chore: fix formatter ordering in scaling tests

Apply golangci formatter output for scaling tests so gci/gofumpt checks pass in CI.



* test: align integration suites with 18-decimal-only config

Remove non-18-decimal integration cases and fee checks that now fail by design under enforced 18-decimal EVM coin configuration.



---------


(cherry picked from commit 264aa70f18f4217b0354855a0c056e19c2f51b51)

* fix conflicts

* fix formatting

* remove the requirement that the EVM coin be configured with 18 decimals

* sum the base and extended denom amounts when parsing balance change events

---------

# Description

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review. -->

<!-- Please keep your PR as draft until it's ready for review -->

<!-- Pull requests that sit inactive for longer than 30 days will be closed.  -->

Closes: #XXXX

---

## Author Checklist

**All** items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.

I have...

- [ ] tackled an existing issue or discussed with a team member
- [ ] left instructions on how to review the changes
- [ ] targeted the `main` branch
